### PR TITLE
Fix server mod check

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,4 @@
 dependencies {
 	api 'com.azanor:Thaumcraft:1.7.10-4.2.3.5:deobf'
-	runtimeOnly 'com.github.GTNewHorizons:Baubles:1.0.3:dev'
+	runtimeOnly 'com.github.GTNewHorizons:Baubles:1.0.4:dev'
 }

--- a/src/main/java/net/blay09/mods/tcinventoryscan/TCInventoryScanning.java
+++ b/src/main/java/net/blay09/mods/tcinventoryscan/TCInventoryScanning.java
@@ -1,11 +1,15 @@
 package net.blay09.mods.tcinventoryscan;
 
+import java.util.Map;
+
 import net.blay09.mods.tcinventoryscan.net.NetworkHandler;
 
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.network.NetworkCheckHandler;
+import cpw.mods.fml.relauncher.Side;
 
 @Mod(
         modid = TCInventoryScanning.MOD_ID,
@@ -22,6 +26,8 @@ public class TCInventoryScanning {
             serverSide = "net.blay09.mods.tcinventoryscan.CommonProxy")
     public static CommonProxy proxy;
 
+    public static boolean isServerSideInstalled = false;
+
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
         proxy.init(event);
@@ -32,5 +38,13 @@ public class TCInventoryScanning {
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
         proxy.postInit(event);
+    }
+
+    @NetworkCheckHandler
+    public boolean checkNetwork(Map<String, String> map, Side side) {
+        if (side == Side.SERVER) {
+            isServerSideInstalled = map.containsKey(MOD_ID);
+        }
+        return true;
     }
 }

--- a/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
+++ b/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
@@ -87,6 +87,7 @@ public class ClientProxy extends CommonProxy {
                             new ChatComponentText(
                                     "This server does not have Thaumcraft Inventory Scanning installed. It will be disabled."));
                     missingMessageSent = true;
+                    isEnabled = false;
                 }
                 return;
             }

--- a/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
+++ b/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
@@ -1,6 +1,7 @@
 package net.blay09.mods.tcinventoryscan.client;
 
 import net.blay09.mods.tcinventoryscan.CommonProxy;
+import net.blay09.mods.tcinventoryscan.TCInventoryScanning;
 import net.blay09.mods.tcinventoryscan.net.MessageScanSelf;
 import net.blay09.mods.tcinventoryscan.net.MessageScanSlot;
 import net.blay09.mods.tcinventoryscan.net.NetworkHandler;
@@ -30,7 +31,6 @@ import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.TickEvent;
-import cpw.mods.fml.common.network.FMLNetworkEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -50,10 +50,8 @@ public class ClientProxy extends CommonProxy {
     private static final int INVENTORY_PLAYER_WIDTH = 52;
     private static final int INVENTORY_PLAYER_HEIGHT = 70;
 
-    private static final int HELLO_TIMEOUT = 20 * 60;
-
-    private int helloTimeout;
     private boolean isEnabled;
+    private boolean missingMessageSent;
     private Item thaumometer;
     private Slot mouseSlot;
     private Slot lastScannedSlot;
@@ -79,28 +77,20 @@ public class ClientProxy extends CommonProxy {
     }
 
     @SubscribeEvent
-    public void connectedToServer(FMLNetworkEvent.ClientConnectedToServerEvent event) {
-        helloTimeout = HELLO_TIMEOUT;
-        isEnabled = false;
-    }
-
-    @SubscribeEvent
     public void clientTick(TickEvent.ClientTickEvent event) {
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayer entityPlayer = mc.thePlayer;
         if (entityPlayer != null) {
-            if (helloTimeout > 0) {
-                helloTimeout--;
-                if (helloTimeout <= 0) {
+            if (!TCInventoryScanning.isServerSideInstalled) {
+                if (!missingMessageSent) {
                     entityPlayer.addChatMessage(
                             new ChatComponentText(
-                                    "This server does not have Crafting Tweaks installed. It will be disabled."));
-                    isEnabled = false;
+                                    "This server does not have Thaumcraft Inventory Scanning installed. It will be disabled."));
+                    missingMessageSent = true;
                 }
-            }
-            if (!isEnabled) {
                 return;
             }
+
             ItemStack mouseItem = entityPlayer.inventory.getItemStack();
             if (mouseItem != null && mouseItem.getItem() == thaumometer) {
                 if (mouseSlot != null && mouseSlot.getStack() != null
@@ -335,12 +325,5 @@ public class ClientProxy extends CommonProxy {
                 && mouseX < gui.guiLeft + INVENTORY_PLAYER_X + INVENTORY_PLAYER_WIDTH
                 && mouseY >= gui.guiTop + INVENTORY_PLAYER_Y
                 && mouseY < gui.guiTop + INVENTORY_PLAYER_Y + INVENTORY_PLAYER_HEIGHT;
-    }
-
-    @Override
-    public void receivedHello(EntityPlayer entityPlayer) {
-        super.receivedHello(entityPlayer);
-        helloTimeout = 0;
-        isEnabled = true;
     }
 }


### PR DESCRIPTION
This fixes an issue where the check for if this was installed server side was done very poorly, meaning that it would fail in singleplayer worlds and incorrectly disable the mod.

This is https://github.com/TwelveIterationMods/ThaumicInventoryScanning/issues/24 on upstream, and it was fixed in the 1.12 version, this is mostly just a backport of that.

Also updated the message to be accurate and not say Craft Tweaker, and udpated baubles dep to latest because why not