### PR TITLE
Ignored Aspectless items, improved code readability

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,3 @@
-
 pluginManagement {
     repositories {
         maven {

--- a/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
+++ b/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
@@ -18,7 +18,6 @@ import net.minecraft.inventory.SlotCrafting;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChatComponentText;
-import net.minecraft.world.World;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
@@ -87,7 +86,6 @@ public class ClientProxy extends CommonProxy {
     public void clientTick(TickEvent.ClientTickEvent event) {
         Minecraft mc = Minecraft.getMinecraft();
         EntityPlayer player = mc.thePlayer;
-        World world = mc.theWorld.provider.worldObj;
         if (player == null) return;
         ItemStack mouseItem = player.inventory.getItemStack();
         if (mouseItem != null && mouseItem.getItem() == thaumometer) {
@@ -98,7 +96,8 @@ public class ClientProxy extends CommonProxy {
                         mouseSlot.getStack().getItemDamage(),
                         null,
                         "");
-                Map<Aspect, Integer> selectedItemAspectList = ScanManager.getScanAspects(result, world).aspects;
+                Map<Aspect, Integer> selectedItemAspectList = ScanManager
+                        .getScanAspects(result, mc.theWorld.provider.worldObj).aspects;
                 if ((!selectedItemAspectList.isEmpty())) {
                     ticksHovered++;
                     if (currentScan == null) currentScan = result;

--- a/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
+++ b/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
@@ -119,10 +119,7 @@ public class ClientProxy extends CommonProxy {
         // Null checks
         if (player == null || hoveringSlot == null
                 || hoveringSlot.getStack() == null
-                || (selectedItem = player.inventory.getItemStack()) == null)
-            return;
-        // If thaumometer is unselected/dropped
-        if (selectedItem.getItem() != thaumometer) {
+                || (selectedItem = player.inventory.getItemStack()) == null || selectedItem.getItem() != thaumometer) {
             ticksHovered = 0;
             currentScan = null;
             isValidSlot = false;
@@ -199,6 +196,7 @@ public class ClientProxy extends CommonProxy {
             EntityPlayer entityPlayer = mc.thePlayer;
             isHoveringOverPlayer = isHoveringPlayer((GuiContainer) event.gui, event.mouseX, event.mouseY);
             hoveringSlot = ((GuiContainer) event.gui).getSlotAtPosition(event.mouseX, event.mouseY);
+            // TODO: Aspects not shown in UI
             if (currentScan != null) {
                 renderScanningProgress(event.gui, event.mouseX, event.mouseY, ticksHovered / (float) SCAN_TICKS);
                 if (!isHoveringOverPlayer) {

--- a/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
+++ b/src/main/java/net/blay09/mods/tcinventoryscan/client/ClientProxy.java
@@ -42,7 +42,6 @@ public class ClientProxy extends CommonProxy {
 
     private static final int SCAN_TICKS = 50;
     private static final int SOUND_TICKS = 5;
-
     private static final int INVENTORY_PLAYER_X = 26;
     private static final int INVENTORY_PLAYER_Y = 8;
     private static final int INVENTORY_PLAYER_WIDTH = 52;
@@ -132,25 +131,25 @@ public class ClientProxy extends CommonProxy {
             cancel();
             return;
         }
-        switch ((isValidSlot ? 0 : 1) + ((hoveringSlot == lastHoveredSlot ? 0 : 10))) {
-            // Valid item + unchanged slots
-            case 0:
-                // Scan the item
+        // Check if the cursor moved to a different slot
+        if (hoveringSlot == lastHoveredSlot) {
+            // Slots did not change
+            if (isValidSlot) {
+                // Scan Slot
                 ticksHovered++;
                 playScanningSoundTick(player);
                 if (ticksHovered >= SCAN_TICKS) tryCompleteScan(player);
-                break;
-            // Invalid item + unchanged slots
-            case 1:
-                // In case of sudden jump to player sprite, recheck if player is selected
-                if (!isHoveringOverPlayer) return;
-                // Valid/invalid item + changed slots
-            case 10:
-            case 11:
-                // Cancel scanning
-                cancel();
-                // Reevaluate item
-                simulateScan(player);
+            } else {
+                // Check if there was a sudden jump to player sprite, otherwise do nothing
+                if (isHoveringOverPlayer) {
+                    cancel();
+                    simulateScan(player);
+                }
+            }
+        } else {
+            // Slots have changed, recheck if the new one can be scanned
+            cancel();
+            simulateScan(player);
         }
         lastHoveredSlot = hoveringSlot;
     }


### PR DESCRIPTION
# Changed Behaviour:
- Inventory scanning with Thaumometer now ignores aspectless items that cannot be scanned like Tinkers Tools.
- Refactored code to improve readability
- Added comments

# Removed:
- No longer displays a chat message on joining a server if the server does not have this mod installed, functionality and Thaumometer tooltip is still disabled in this case.

# Tests:
- All tests were on GTNH version 2.5.1
- Tested and working as intended locally in SP, on locally hosted server in MP, and on remotely hosted server running a non-updated version of this mod.

![2024-03-14_17 34 11](https://github.com/GTNewHorizons/ThaumicInventoryScanning/assets/58092051/03cc1a65-a97b-485e-b499-7f47d508084d)