### PR TITLE
Disable `useDependencyInformation`

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,4 +1,4 @@
 dependencies {
-	api 'com.azanor:Thaumcraft:1.7.10-4.2.3.5:deobf'
+	api 'thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev'
 	runtimeOnly 'com.github.GTNewHorizons:Baubles:1.0.4:dev'
 }

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -12,10 +12,6 @@
 		"credits": "",
 		"logoFile": "",
 		"screenshots": [],
-		"parent": "",
-		"requiredMods": ["Thaumcraft"],
-		"dependencies": ["Thaumcraft"],
-		"dependants": [],
-		"useDependencyInformation": true
+		"parent": ""
 	}]
 }


### PR DESCRIPTION
`"useDependencyInformation": true` overrides the dependencies declared in the `@Mod` annotation with the dependencies declared in this file.